### PR TITLE
Store partition keys with partitioned tables.

### DIFF
--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -47,7 +47,7 @@ module Tablature
       # @param [String, Symbol] table_name The name of the table to partition.
       # @param [Hash] options The options to create the partition. Keys besides +:partition_key+
       #   will be passed to +create_table+.
-      # @option options [String, Symbol] :partition_key The partition key.
+      # @option options [String, Symbol, #call] :partition_key The partition key.
       # @yield [td] A TableDefinition object. This allows creating the table columns the same way
       #   as Rails's +create_table+ does.
       #
@@ -84,7 +84,6 @@ module Tablature
       # @param [String, Symbol] table_name The name of the table to partition.
       # @param [Hash] options The options to create the partition. Keys besides +:partition_key+
       #   will be passed to +create_table+.
-      # @option options [String, Symbol] :partition_key The partition key.
       # @yield [td] A TableDefinition object. This allows creating the table columns the same way
       #   as Rails's +create_table+ does.
       #

--- a/lib/tablature/adapters/postgres/partitioned_tables.rb
+++ b/lib/tablature/adapters/postgres/partitioned_tables.rb
@@ -47,11 +47,11 @@ module Tablature
 
         def to_tablature_table(table_name, rows)
           result = rows.first
-          partioning_method = METHOD_MAP.fetch(result['type'])
+          partitioning_method = METHOD_MAP.fetch(result['type'])
           partitions = rows.map { |row| row['partition_name'] }.compact.map(&method(:unquote))
 
           Tablature::PartitionedTable.new(
-            name: table_name, partioning_method: partioning_method, partitions: partitions
+            name: table_name, partitioning_method: partitioning_method, partitions: partitions
           )
         end
 

--- a/lib/tablature/adapters/postgres/partitioned_tables.rb
+++ b/lib/tablature/adapters/postgres/partitioned_tables.rb
@@ -25,7 +25,8 @@ module Tablature
               c.oid,
               c.relname AS table_name,
               p.partstrat AS type,
-              (i.inhrelid::REGCLASS)::TEXT AS partition_name
+              (i.inhrelid::REGCLASS)::TEXT AS partition_name,
+              pg_get_partkeydef(c.oid) AS partition_key_definition
             FROM pg_class c
               INNER JOIN pg_partitioned_table p ON c.oid = p.partrelid
               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -49,9 +50,15 @@ module Tablature
           result = rows.first
           partitioning_method = METHOD_MAP.fetch(result['type'])
           partitions = rows.map { |row| row['partition_name'] }.compact.map(&method(:unquote))
+          # This is very fragile code. This makes the assumption that:
+          # - Postgres will always have a function `pg_get_partkeydef` that returns the partition
+          # method with the partition key
+          # - Postgres will never have a partition method with two words in its name.
+          _, partition_key = result['partition_key_definition'].split(' ', 2)
 
           Tablature::PartitionedTable.new(
-            name: table_name, partitioning_method: partitioning_method, partitions: partitions
+            name: table_name, partitioning_method: partitioning_method,
+            partitions: partitions, partition_key: partition_key
           )
         end
 

--- a/lib/tablature/adapters/postgres/quoting.rb
+++ b/lib/tablature/adapters/postgres/quoting.rb
@@ -4,7 +4,11 @@ module Tablature
       # @api private
       module Quoting
         def quote_partition_key(key)
-          key.to_s.split('::').map(&method(:quote_column_name)).join('::')
+          if key.respond_to?(:call)
+            key.call.to_s
+          else
+            key.to_s.split('::').map(&method(:quote_column_name)).join('::')
+          end
         end
 
         def quote_collection(values)

--- a/lib/tablature/partitioned_table.rb
+++ b/lib/tablature/partitioned_table.rb
@@ -19,6 +19,10 @@ module Tablature
     # @return [Array]
     attr_reader :partitions
 
+    # The partition key expression.
+    # @return [String]
+    attr_reader :partition_key
+
     # Returns a new instance of PartitionTable.
     #
     # @param name [String] The name of the view.
@@ -29,6 +33,7 @@ module Tablature
       @name = name
       @partitioning_method = partitioning_method
       @partitions = partitions
+      @partition_key = partition_key
     end
   end
 end

--- a/lib/tablature/partitioned_table.rb
+++ b/lib/tablature/partitioned_table.rb
@@ -13,7 +13,7 @@ module Tablature
 
     # The partitioning method of the table
     # @return [Symbol]
-    attr_reader :partioning_method
+    attr_reader :partitioning_method
 
     # The partitions of the table.
     # @return [Array]
@@ -22,11 +22,12 @@ module Tablature
     # Returns a new instance of PartitionTable.
     #
     # @param name [String] The name of the view.
-    # @param partioning_method [:symbol] One of :range, :list or :hash
+    # @param partitioning_method [:symbol] One of :range, :list or :hash
     # @param partitions [Array] The partitions of the table.
-    def initialize(name:, partioning_method:, partitions: [])
+    # @param partition_key [String] The partition key expression.
+    def initialize(name:, partitioning_method:, partitions: [], partition_key:)
       @name = name
-      @partioning_method = partioning_method
+      @partitioning_method = partitioning_method
       @partitions = partitions
     end
   end

--- a/spec/tablature/adapters/postgres/partitioned_tables_spec.rb
+++ b/spec/tablature/adapters/postgres/partitioned_tables_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Tablature::Adapters::Postgres::PartitionedTables, :database do
-  it 'returns tablature partionned table object for list partitions' do
+  it 'returns tablature partitioned table object for list partitions' do
     connection = ActiveRecord::Base.connection
     connection.execute <<-SQL
       CREATE TABLE "events" ("id" bigserial NOT NULL) PARTITION BY LIST ("id");

--- a/spec/tablature/adapters/postgres/partitioned_tables_spec.rb
+++ b/spec/tablature/adapters/postgres/partitioned_tables_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe Tablature::Adapters::Postgres::PartitionedTables, :database do
     SQL
 
     tables = described_class.new(connection).all
-    first = tables.first
+    partitioned_table = tables.first
 
     expect(tables.size).to eq(1)
-    expect(first.name).to eq('events')
-    expect(first.partioning_method).to eq(:list)
-    expect(first.partitions).to include('events_10')
+    expect(partitioned_table.name).to eq('events')
+    expect(partitioned_table.partition_key).to eq('(id)')
+    expect(partitioned_table.partitioning_method).to eq(:list)
+    expect(partitioned_table.partitions).to include('events_10')
   end
 
   it 'returns tablature partionned table object for range partitions' do
@@ -25,12 +26,13 @@ RSpec.describe Tablature::Adapters::Postgres::PartitionedTables, :database do
     SQL
 
     tables = described_class.new(connection).all
-    first = tables.first
+    partitioned_table = tables.first
 
     expect(tables.size).to eq(1)
-    expect(first.name).to eq('events')
-    expect(first.partioning_method).to eq(:range)
-    expect(first.partitions).to include('events_10')
+    expect(partitioned_table.name).to eq('events')
+    expect(partitioned_table.partition_key).to eq('(id)')
+    expect(partitioned_table.partitioning_method).to eq(:range)
+    expect(partitioned_table.partitions).to include('events_10')
   end
 
   it 'returns tablature partionned table object for hash partitions', :postgres_11 do
@@ -43,11 +45,51 @@ RSpec.describe Tablature::Adapters::Postgres::PartitionedTables, :database do
     SQL
 
     tables = described_class.new(connection).all
-    first = tables.first
+    partitioned_table = tables.first
 
     expect(tables.size).to eq(1)
-    expect(first.name).to eq('events')
-    expect(first.partioning_method).to eq(:hash)
-    expect(first.partitions).to match_array(['events_0', 'events_1', 'events_2'])
+    expect(partitioned_table.name).to eq('events')
+    expect(partitioned_table.partition_key).to eq('(id)')
+    expect(partitioned_table.partitioning_method).to eq(:hash)
+    expect(partitioned_table.partitions).to match_array(['events_0', 'events_1', 'events_2'])
+  end
+
+  it 'correctly handles partitions with expressions as partition key' do
+    connection = ActiveRecord::Base.connection
+    connection.execute <<-SQL
+      CREATE TABLE "events" ("id" bigserial NOT NULL, ts timestamp NOT NULL) PARTITION BY RANGE ((ts::date));
+      CREATE TABLE "events_2019" PARTITION OF "events" FOR VALUES FROM ('2019-01-01') TO ('2020-01-01');
+    SQL
+
+    tables = described_class.new(connection).all
+    partitioned_table = tables.first
+
+    expect(partitioned_table.partition_key).to eq('(((ts)::date))')
+  end
+
+  it 'correctly handles partitions with multiple columns as partition key' do
+    connection = ActiveRecord::Base.connection
+    connection.execute <<-SQL
+      CREATE TABLE "events" ("id" bigserial NOT NULL, date date NOT NULL) PARTITION BY RANGE (id, date);
+      CREATE TABLE "events_2019" PARTITION OF "events" FOR VALUES FROM (1, '2019-01-01') TO (100, '2020-01-01');
+    SQL
+
+    tables = described_class.new(connection).all
+    partitioned_table = tables.first
+
+    expect(partitioned_table.partition_key).to eq('(id, date)')
+  end
+
+  it 'correctly handles partitions with columns and expressions as partition key' do
+    connection = ActiveRecord::Base.connection
+    connection.execute <<-SQL
+      CREATE TABLE "events" ("id" bigserial NOT NULL, ts timestamp NOT NULL) PARTITION BY RANGE (id, (ts::date));
+      CREATE TABLE "events_2019" PARTITION OF "events" FOR VALUES FROM (1, '2019-01-01') TO (100, '2020-01-01');
+    SQL
+
+    tables = described_class.new(connection).all
+    partitioned_table = tables.first
+
+    expect(partitioned_table.partition_key).to eq('(id, ((ts)::date))')
   end
 end


### PR DESCRIPTION
This will be useful when dumping the partitioned tables in the `schema.rb`.