### PR TITLE
Allow attaching and detaching partitions

### DIFF
--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -73,7 +73,8 @@ module Tablature
       # @example
       #   # With a table :events partitioned using the list method on the partition key `date`:
       #   create_list_partition_of :events, name: "events_2018-W49", values: [
-      #     "2018-12-03", "2018-12-04", "2018-12-05", "2018-12-06", "2018-12-07", "2018-12-08", "2018-12-09"
+      #     "2018-12-03", "2018-12-04", "2018-12-05", "2018-12-06", "2018-12-07", "2018-12-08",
+      #     "2018-12-09"
       #   ]
       delegate :create_list_partition_of, to: :list_handler
 
@@ -88,7 +89,8 @@ module Tablature
       # @example
       #   # With a table :events partitioned using the list method on the partition key `date`:
       #   attach_to_list_partition :events, name: "events_2018-W49", values: [
-      #     "2018-12-03", "2018-12-04", "2018-12-05", "2018-12-06", "2018-12-07", "2018-12-08", "2018-12-09"
+      #     "2018-12-03", "2018-12-04", "2018-12-05", "2018-12-06", "2018-12-07", "2018-12-08",
+      #     "2018-12-09"
       #   ]
       delegate :attach_to_list_partition, to: :list_handler
 

--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -77,6 +77,33 @@ module Tablature
       #   ]
       delegate :create_list_partition_of, to: :list_handler
 
+      # @!method attach_to_list_partition(parent_table_name, options)
+      # Attaches a partition to a parent by specifying the key values appearing in the partition.
+      #
+      # @param parent_table_name [String, Symbol] The name of the parent table.
+      # @param [Hash] options The options to attach the partition.
+      # @option options [String, Symbol] :name The name of the partition.
+      # @option options [String, Symbol] :values The values appearing in the partition.
+      #
+      # @example
+      #   # With a table :events partitioned using the list method on the partition key `date`:
+      #   attach_to_list_partition :events, name: "events_2018-W49", values: [
+      #     "2018-12-03", "2018-12-04", "2018-12-05", "2018-12-06", "2018-12-07", "2018-12-08", "2018-12-09"
+      #   ]
+      delegate :attach_to_list_partition, to: :list_handler
+
+      # @!method detach_from_list_partition(parent_table_name, options)
+      # Detaches a partition from a parent.
+      #
+      # @param parent_table_name [String, Symbol] The name of the parent table.
+      # @param [Hash] options The options to create the partition.
+      # @option options [String, Symbol] :name The name of the partition.
+      #
+      # @example
+      #   # With a table :events partitioned using the list method on the partition key `date`:
+      #   detach_from_list_partition :events, name: "events_2018-W49"
+      delegate :detach_from_list_partition, to: :list_handler
+
       # @!method create_range_partition(table_name, options, &block)
       # Creates a partitioned table using the range partition method.
       #

--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -132,12 +132,12 @@ module Tablature
       #
       # @param parent_table_name [String, Symbol] The name of the parent table.
       # @param [Hash] options The options to create the partition.
+      # @option options [String, Symbol] :name The name of the partition. If it is not given, this
+      #   will be randomly generated.
       # @option options [String, Symbol] :range_start The start of the range of values appearing in
       #   the partition.
       # @option options [String, Symbol] :range_end The end of the range of values appearing in
       #   the partition.
-      # @option options [String, Symbol] :name The name of the partition. If it is not given, this
-      #   will be randomly generated.
       # @option options [Boolean] :default Whether the partition is the default partition or not.
       #
       # @example
@@ -145,6 +145,35 @@ module Tablature
       #   create_range_partition_of :events, name: "events_2018-W49", range_start: '2018-12-03',
       #                                                               range_end: '2018-12-10'
       delegate :create_range_partition_of, to: :range_handler
+
+      # @!method attach_to_range_partition(parent_table_name, options)
+      # Attaches a partition to a parent by specifying the key values appearing in the partition.
+      #
+      # @param parent_table_name [String, Symbol] The name of the parent table.
+      # @param [Hash] options The options to create the partition.
+      # @option options [String, Symbol] :name The name of the partition.
+      # @option options [String, Symbol] :range_start The start of the range of values appearing in
+      #   the partition.
+      # @option options [String, Symbol] :range_end The end of the range of values appearing in
+      #   the partition.
+      # @option options [Boolean] :default Whether the partition is the default partition or not.
+      #
+      # @example
+      #   # With a table :events partitioned using the range method on the partition key `date`:
+      #   attach_to_range_partition :events, name: "events_2018-W49", range_start: '2018-12-03',
+      #                                                               range_end: '2018-12-10'
+      delegate :attach_to_range_partition, to: :range_handler
+
+      # @!method detach_from_range_partition(parent_table_name, options)
+      # Detaches a partition from a parent.
+      #
+      # @param parent_table_name [String, Symbol] The name of the parent table.
+      # @param [Hash] options The options to detach the partition.
+      # @option options [String, Symbol] :name The name of the partition.
+      #
+      # @example
+      #   detach_from_range_partition :events, name: "events_2018-W49"
+      delegate :detach_from_range_partition, to: :range_handler
 
       # Returns an array of partitioned tables in the database.
       #

--- a/lib/tablature/adapters/postgres/errors.rb
+++ b/lib/tablature/adapters/postgres/errors.rb
@@ -11,6 +11,13 @@ module Tablature
         end
       end
 
+      # Raised when trying to attach or detach a partition without supplying a name.
+      class MissingPartitionName < StandardError
+        def initialize
+          super('Missing partition name')
+        end
+      end
+
       # Raised when a list partition operation is attempted on a database
       # version that does not support list partitions.
       #

--- a/lib/tablature/statements.rb
+++ b/lib/tablature/statements.rb
@@ -26,6 +26,18 @@ module Tablature
       Tablature.database.create_list_partition_of(parent_table_name, options)
     end
 
+    def attach_to_list_partition(parent_table_name, options)
+      raise ArgumentError, 'partition_name must be defined' if options[:partition_name]
+
+      Tablature.database.attach_to_list_partition(parent_table_name)
+    end
+
+    def detach_from_list_partition(parent_table_name, options)
+      raise ArgumentError, 'partition_name must be defined' if options[:partition_name]
+
+      Tablature.database.attach_to_list_partition(parent_table_name)
+    end
+
     # Creates a partitioned table using the range partition method.
     #
     # @param name [String, Symbol] The name of the partition.

--- a/spec/tablature/adapters/postgres_spec.rb
+++ b/spec/tablature/adapters/postgres_spec.rb
@@ -192,4 +192,73 @@ RSpec.describe Tablature::Adapters::Postgres, :database do
       expect(partitioned_table.partitions.map(&:name)).to include('events_1')
     end
   end
+
+  describe 'attach_to_range_partition' do
+    it 'raises if the partition bounds and the default flag are missing' do
+      adapter = described_class.new
+      adapter.create_range_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_range_partition_of('events', name: 'events_a', range_start: 1, range_end: 2)
+      adapter.detach_from_range_partition('events', name: 'events_a')
+
+      expect { adapter.attach_to_range_partition('events', name: 'events_a') }
+        .to raise_error described_class::MissingRangePartitionBoundsError
+    end
+
+    it 'raises if the name is missing' do
+      adapter = described_class.new
+      adapter.create_range_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_range_partition_of('events', name: 'events_a', range_start: 1, range_end: 2)
+      adapter.detach_from_range_partition('events', name: 'events_a')
+
+      expect { adapter.attach_to_range_partition('events', range_start: 1, range_end: 2) }
+        .to raise_error described_class::MissingPartitionName
+    end
+
+    it 'attaches the partition' do
+      adapter = described_class.new
+      adapter.create_range_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_range_partition_of('events', name: 'events_a', range_start: 1, range_end: 2)
+      adapter.detach_from_range_partition('events', name: 'events_a')
+
+      adapter.attach_to_range_partition('events', name: 'events_a', range_start: 1, range_end: 2)
+      partitioned_table = adapter.partitioned_tables.find { |t| t.name == 'events' }
+
+      expect(partitioned_table.partitions.map(&:name)).to include('events_a')
+    end
+  end
+
+  describe 'detach_from_range_partition' do
+    it 'raises if the name is missing' do
+      adapter = described_class.new
+      adapter.create_range_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_range_partition_of('events', name: 'events_a', range_start: 1, range_end: 2)
+      expect { adapter.detach_from_range_partition('events', {}) }
+        .to raise_error described_class::MissingPartitionName
+    end
+
+    it 'detaches the partition' do
+      adapter = described_class.new
+      adapter.create_range_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_range_partition_of('events', name: 'events_a', range_start: 1, range_end: 2)
+      adapter.detach_from_range_partition('events', name: 'events_a')
+
+      partitioned_table = adapter.partitioned_tables.find { |t| t.name == 'events' }
+      expect(partitioned_table.partitions.map(&:name)).to_not include('events_a')
+    end
+  end
 end

--- a/spec/tablature/adapters/postgres_spec.rb
+++ b/spec/tablature/adapters/postgres_spec.rb
@@ -62,6 +62,76 @@ RSpec.describe Tablature::Adapters::Postgres, :database do
     end
   end
 
+  describe '#attach_to_list_partition' do
+    it 'raises if the list values and the default flag are missing' do
+      adapter = described_class.new
+      adapter.create_list_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_list_partition_of('events', name: 'events_a', values: [1, 2])
+      adapter.detach_from_list_partition('events', name: 'events_a')
+
+      expect { adapter.attach_to_list_partition('events', name: 'events_a') }
+        .to raise_error described_class::MissingListPartitionValuesError
+    end
+
+    it 'raises if the name is missing' do
+      adapter = described_class.new
+      adapter.create_list_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_list_partition_of('events', name: 'events_a', values: [1, 2])
+      adapter.detach_from_list_partition('events', name: 'events_a')
+
+      expect { adapter.attach_to_list_partition('events', values: [1, 2]) }
+        .to raise_error described_class::MissingPartitionName
+    end
+
+    it 'attaches the partition' do
+      adapter = described_class.new
+      adapter.create_list_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_list_partition_of('events', name: 'events_a', values: [1, 2])
+      adapter.detach_from_list_partition('events', name: 'events_a')
+
+      adapter.attach_to_list_partition('events', name: 'events_a', values: [1, 2])
+      partitioned_table = adapter.partitioned_tables.find { |t| t.name == 'events' }
+
+      expect(partitioned_table.partitions.map(&:name)).to include('events_a')
+    end
+  end
+
+  describe '#detach_from_list_partition' do
+    it 'raises if the name is missing' do
+      adapter = described_class.new
+      adapter.create_list_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_list_partition_of('events', name: 'events_a', values: [1, 2])
+
+      expect { adapter.detach_from_list_partition('events', {}) }
+        .to raise_error described_class::MissingPartitionName
+    end
+
+    it 'detaches the partition' do
+      adapter = described_class.new
+      adapter.create_list_partition 'events', partition_key: 'event_id' do |t|
+        t.integer :event_id, null: false
+      end
+
+      adapter.create_list_partition_of('events', name: 'events_a', values: [1, 2])
+      adapter.detach_from_list_partition('events', name: 'events_a')
+
+      partitioned_table = adapter.partitioned_tables.find { |t| t.name == 'events' }
+      expect(partitioned_table.partitions.map(&:name)).to_not include('events_a')
+    end
+  end
+
   describe '#create_range_partition' do
     it 'raises if the databases does not support range partitions' do
       # TODO: Find a way to mock `supports_range_partitions?` instead of the postgres version.


### PR DESCRIPTION
### Attaching and detaching
- This adds method to attach and detach partitions, for both list and range partitions.
- For now, there's two method by partition method, in the future we could have methods handling all partitioning methods.
Overrides #26, closes #7 

### Misc Things
- Move stuff around in docs.