### PR TITLE
Dump partitions in schema.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,11 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
 gem 'rubocop'
 
-rails_version = ENV.fetch("RAILS_VERSION", "6.0")
+rails_version = ENV.fetch('RAILS_VERSION', '6.0')
 
-if rails_version == "master"
-  rails_constraint = { github: "rails/rails" }
-else
-  rails_constraint = "~> #{rails_version}.0"
-end
+rails_constraint = rails_version == 'master' ? { github: 'rails/rails' } : "~> #{rails_version}.0"
 
-gem "rails", rails_constraint
+gem 'rails', rails_constraint

--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -4,6 +4,7 @@ require_relative 'postgres/connection'
 require_relative 'postgres/errors'
 require_relative 'postgres/handlers/list'
 require_relative 'postgres/handlers/range'
+require_relative 'postgres/indexes'
 require_relative 'postgres/partitioned_tables'
 
 module Tablature
@@ -183,6 +184,14 @@ module Tablature
       # @return [Array<Tablature::PartitionedTable]
       def partitioned_tables
         PartitionedTables.new(connection).all
+      end
+
+      # Indexes on the Partitioned Table.
+      #
+      # @param name [String] The name of the partitioned table we want indexes from.
+      # @return [Array<ActiveRecord::ConnectionAdapters::IndexDefinition>]
+      def indexes_on(partitioned_table)
+        Indexes.new(connection).on(partitioned_table)
       end
 
       private

--- a/lib/tablature/adapters/postgres.rb
+++ b/lib/tablature/adapters/postgres.rb
@@ -191,6 +191,9 @@ module Tablature
       # @param name [String] The name of the partitioned table we want indexes from.
       # @return [Array<ActiveRecord::ConnectionAdapters::IndexDefinition>]
       def indexes_on(partitioned_table)
+        return [] if Gem::Version.new(Rails.version) >= Gem::Version.new('6.0.3')
+        return [] unless connection.supports_indexes_on_partitioned_tables?
+
         Indexes.new(connection).on(partitioned_table)
       end
 

--- a/lib/tablature/adapters/postgres/connection.rb
+++ b/lib/tablature/adapters/postgres/connection.rb
@@ -38,6 +38,13 @@ module Tablature
           postgresql_version >= 110_000
         end
 
+        # True if the connection supports indexes on partitioned tables.
+        #
+        # @return [Boolean]
+        def supports_indexes_on_partitioned_tables?
+          postgresql_version >= 110_000
+        end
+
         # An integer representing the version of Postgres we're connected to.
         #
         # +postgresql_version+ is public in Rails 5, but protected in earlier

--- a/lib/tablature/adapters/postgres/indexes.rb
+++ b/lib/tablature/adapters/postgres/indexes.rb
@@ -1,0 +1,96 @@
+module Tablature
+  module Adapters
+    class Postgres
+      # Fetches indexes on objects from the Postgres connection.
+      #
+      # @api private
+      class Indexes
+        def initialize(connection)
+          @connection = connection
+        end
+
+        def on(name)
+          indexes_on(name).map(&method(:index_from_database))
+        end
+
+        private
+
+        attr_reader :connection
+
+        def indexes_on(name)
+          connection.exec_query(<<-SQL, 'SCHEMA').to_a
+            SELECT DISTINCT
+              i.relname AS index_name,
+              d.indisunique AS is_unique,
+              d.indkey AS index_keys,
+              pg_get_indexdef(d.indexrelid) AS definition,
+              t.oid AS oid,
+              pg_catalog.obj_description(i.oid, 'pg_class') AS comment,
+              t.relname AS table_name,
+              string_agg(a.attname, ',') OVER (PARTITION BY i.relname) AS column_names
+            FROM pg_class t
+            INNER JOIN pg_index d ON t.oid = d.indrelid
+            INNER JOIN pg_class i ON d.indexrelid = i.oid
+            LEFT JOIN pg_namespace n ON n.oid = i.relnamespace
+            LEFT JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY (d.indkey)
+            WHERE i.relkind = 'I'
+              AND d.indisprimary = 'f'
+              AND t.relname = '#{name}'
+              AND n.nspname = ANY (current_schemas(false))
+            ORDER BY i.relname
+          SQL
+        end
+
+        def index_from_database(result)
+          result = format_result(result)
+
+          if rails_version >= Gem::Version.new('5.2')
+            ActiveRecord::ConnectionAdapters::IndexDefinition.new(
+              result['table_name'], result['index_name'], result['is_unique'], result['columns'],
+              lengths: {}, orders: result['orders'], opclasses: result['opclasses'],
+              where: result['where'], using: result['using'].to_sym,
+              comment: result['comment'].presence
+            )
+          elsif rails_version >= Gem::Version.new('5.0')
+            ActiveRecord::ConnectionAdapters::IndexDefinition.new(
+              result['table_name'], result['index_name'], result['is_unique'], result['columns'],
+              {}, result['orders'], result['where'], nil, result['using'].to_sym,
+              result['comment'].presence
+            )
+          end
+        end
+
+        INDEX_PATTERN = /(?<column>\w+)"?\s?(?<opclass>\w+_ops)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/.freeze
+        private_constant :INDEX_PATTERN
+
+        USING_PATTERN = / USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m.freeze
+        private_constant :USING_PATTERN
+
+        def format_result(result)
+          result['index_keys'] = result['index_keys'].split.map(&:to_i)
+          result['column_names'] = result['column_names'].split(',')
+          result['using'], expressions, result['where'] = result['definition'].scan(USING_PATTERN).flatten
+          result['columns'] = result['index_keys'].include?(0) ? expressions : result['column_names']
+
+          result['orders'] = {}
+          result['opclasses'] = {}
+
+          expressions.scan(INDEX_PATTERN).each do |column, opclass, desc, nulls|
+            result['opclasses'][column] = opclass.to_sym if opclass
+            if nulls
+              result['orders'][column] = [desc, nulls].compact.join(' ')
+            elsif desc
+              result['orders'][column] = :desc
+            end
+          end
+
+          result
+        end
+
+        def rails_version
+          @rails_version ||= Gem::Version.new(Rails.version)
+        end
+      end
+    end
+  end
+end

--- a/lib/tablature/adapters/postgres/partitioned_tables.rb
+++ b/lib/tablature/adapters/postgres/partitioned_tables.rb
@@ -19,8 +19,9 @@ module Tablature
 
         attr_reader :connection
 
+        # rubocop:disable Metrics/MethodLength
         def partitions
-          connection.execute(<<-SQL)
+          result = connection.exec_query(<<-SQL, 'SCHEMA')
             SELECT
               c.oid,
               i.inhrelid,
@@ -39,7 +40,10 @@ module Tablature
               AND n.nspname = ANY (current_schemas(false))
             ORDER BY c.oid
           SQL
+
+          result.to_a
         end
+        # rubocop:enable Metrics/MethodLength
 
         STRATEGY_MAP = {
           'l' => :list,

--- a/lib/tablature/adapters/postgres/quoting.rb
+++ b/lib/tablature/adapters/postgres/quoting.rb
@@ -4,11 +4,12 @@ module Tablature
       # @api private
       module Quoting
         def quote_partition_key(key)
-          if key.respond_to?(:call)
-            key.call.to_s
-          else
-            key.to_s.split('::').map(&method(:quote_column_name)).join('::')
-          end
+          return key.call.to_s if key.respond_to?(:call)
+          # Don't bother quoting the key if it is already quoted (when loading the schema for
+          # example).
+          return key if key.to_s.include?("'") || key.to_s.include?('"')
+
+          key.to_s.split('::').map(&method(:quote_column_name)).join('::')
         end
 
         def quote_collection(values)

--- a/lib/tablature/model.rb
+++ b/lib/tablature/model.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Tablature
   module Model
     module ListPartitionMethods

--- a/lib/tablature/partitioned_table.rb
+++ b/lib/tablature/partitioned_table.rb
@@ -55,6 +55,21 @@ module Tablature
       partitions.find(&:default_partition?)
     end
 
+    PARTITION_METHOD_MAP = {
+      list: 'create_list_partition',
+      range: 'create_range_partition'
+    }.freeze
+    private_constant :PARTITION_METHOD_MAP
+
+    def to_schema
+      return nil unless PARTITION_METHOD_MAP.key?(partitioning_strategy)
+
+      creation_method = PARTITION_METHOD_MAP[partitioning_strategy]
+      <<-CONTENT
+        #{creation_method} #{name.inspect}, partition_key: #{partition_key.inspect} do |t|
+      CONTENT
+    end
+
     def <=>(other)
       name <=> other.name
     end

--- a/lib/tablature/partitioned_table.rb
+++ b/lib/tablature/partitioned_table.rb
@@ -54,5 +54,9 @@ module Tablature
     def default_partition
       partitions.find(&:default_partition?)
     end
+
+    def <=>(other)
+      name <=> other.name
+    end
   end
 end

--- a/lib/tablature/schema_dumper.rb
+++ b/lib/tablature/schema_dumper.rb
@@ -21,6 +21,7 @@ module Tablature
       dumpable_partitioned_tables.each do |partitioned_table|
         dump_partitioned_table(partitioned_table, stream)
         dump_partition_indexes(partitioned_table, stream)
+        dump_foreign_keys(partitioned_table, stream)
       end
     end
 
@@ -75,6 +76,10 @@ module Tablature
 
       stream.puts add_index_statements.sort.join("\n")
       stream.puts
+    end
+
+    def dump_foreign_keys(partitioned_table, stream)
+      foreign_keys(partitioned_table.name, stream)
     end
 
     def dumpable_partitioned_tables

--- a/lib/tablature/schema_dumper.rb
+++ b/lib/tablature/schema_dumper.rb
@@ -67,6 +67,8 @@ module Tablature
       return unless Tablature.database.respond_to?(:indexes_on)
 
       indexes = Tablature.database.indexes_on(partitioned_table.name)
+      return if indexes.empty?
+
       add_index_statements = indexes.map do |index|
         table_name = remove_prefix_and_suffix(index.table).inspect
         "  add_index #{([table_name] + index_parts(index)).join(', ')}"

--- a/lib/tablature/schema_dumper.rb
+++ b/lib/tablature/schema_dumper.rb
@@ -63,7 +63,6 @@ module Tablature
 
     # Delegate to the adapter the dumping of indexes.
     def dump_partition_indexes(partitioned_table, stream)
-      return if Gem::Version.new(Rails.version) >= Gem::Version.new('6.0.3')
       return unless Tablature.database.respond_to?(:indexes_on)
 
       indexes = Tablature.database.indexes_on(partitioned_table.name)

--- a/lib/tablature/schema_dumper.rb
+++ b/lib/tablature/schema_dumper.rb
@@ -1,18 +1,67 @@
+# TODO: Try to replace the creation methods in the main stream instead of dumping the partitioned
+# tables at the end of the schema.
 module Tablature
   # @api private
   module SchemaDumper
     def tables(stream)
       # Add partitions to the list of ignored tables.
       ActiveRecord::SchemaDumper.ignore_tables =
-        (ActiveRecord::SchemaDumper.ignore_tables || []) + partitions
+        (ActiveRecord::SchemaDumper.ignore_tables || []) +
+        dumpable_partitioned_tables.map(&:name) +
+        partitions
 
       super
+
+      partitioned_tables(stream)
+    end
+
+    def partitioned_tables(stream)
+      stream.puts if dumpable_partitioned_tables.any?
+
+      dumpable_partitioned_tables.each do |partitioned_table|
+        dump_partitioned_table(partitioned_table, stream)
+      end
     end
 
     private
 
+    attr_reader :connection
+    delegate :quote_table_name, :quote, to: :connection
+
+    PARTITION_METHOD_MAP = {
+      list: 'create_list_partition',
+      range: 'create_range_partition'
+    }.freeze
+    private_constant :PARTITION_METHOD_MAP
+
+    def dump_partitioned_table(partitioned_table, main_stream)
+      # Pretend the partitioned table is a regular table and dump it in an alternate stream.
+      stream = StringIO.new
+      table(partitioned_table.name, stream)
+
+      # Fetch the creation method for handled partitioning methods, otherwise comment that the
+      # partitioning method is not handled.
+      creation_method = PARTITION_METHOD_MAP.fetch(partitioned_table.partitioning_strategy) do
+        main_stream.puts <<~MESSAGE
+          # Invalid partitioning strategy "#{partitioned_table.partitioning_strategy}" for partitioned table "#{partitioned_table.name}".
+        MESSAGE
+
+        return
+      end
+
+      # Replace the table creation line with our own line using the partition creation method.
+      content = stream.tap(&:rewind).read.gsub(
+        /create_table.*/,
+        <<~CONTENT.strip
+          #{creation_method} #{quote_table_name(partitioned_table.name)}, partition_key: #{quote(partitioned_table.partition_key)} do |t|
+        CONTENT
+      )
+
+      main_stream.puts(content)
+    end
+
     def dumpable_partitioned_tables
-      Tablature.database.partitioned_tables
+      Tablature.database.partitioned_tables.sort
     end
 
     def partitions

--- a/spec/tablature/adapters/postgres/connection_spec.rb
+++ b/spec/tablature/adapters/postgres/connection_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe Tablature::Adapters::Postgres::Connection do
     end
   end
 
+  describe '#supports_indexes_on_partitioned_tables?' do
+    it 'is true if the postgres version is at least 11.0' do
+      base_connection = double('Connection', postgresql_version: 110_000)
+      connection = described_class.new(base_connection)
+
+      expect(connection.supports_indexes_on_partitioned_tables?).to eq(true)
+    end
+
+    it 'is false if the postgres version is less than 11.0' do
+      base_connection = double('Connection', postgresql_version: 109_999)
+      connection = described_class.new(base_connection)
+
+      expect(connection.supports_indexes_on_partitioned_tables?).to eq(false)
+    end
+  end
+
   describe '#postgresql_version' do
     it 'uses the public method on the provided connection if defined' do
       base_connection = Class.new do

--- a/spec/tablature/schema_dumper_spec.rb
+++ b/spec/tablature/schema_dumper_spec.rb
@@ -15,4 +15,14 @@ RSpec.describe Tablature::SchemaDumper, :database do
     output = stream.string
     expect(output).to_not include('events_10')
   end
+
+  it 'dumps create_range_partition for a range partition in the database' do
+    Event.connection.create_range_partition :events, partition_key: :id
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(Event.connection, stream)
+
+    output = stream.string
+    expect(output).to include('create_range_partition "events"')
+  end
 end

--- a/spec/tablature/schema_dumper_spec.rb
+++ b/spec/tablature/schema_dumper_spec.rb
@@ -25,4 +25,15 @@ RSpec.describe Tablature::SchemaDumper, :database do
     output = stream.string
     expect(output).to include('create_range_partition "events"')
   end
+
+  it 'dumps the indexes for the partition' do
+    Event.connection.create_range_partition :events, partition_key: :id
+    Event.connection.add_index :events, :id, name: 'index_on_id'
+    stream = StringIO.new
+
+    ActiveRecord::SchemaDumper.dump(Event.connection, stream)
+
+    output = stream.string
+    expect(output).to match(/index.*name: "index_on_id"/)
+  end
 end

--- a/spec/tablature/schema_dumper_spec.rb
+++ b/spec/tablature/schema_dumper_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Tablature::SchemaDumper, :database do
     expect(output).to include('create_range_partition "events"')
   end
 
-  it 'dumps the indexes for the partition' do
+  it 'dumps the indexes for the partition', :postgres_11 do
     Event.connection.create_range_partition :events, partition_key: :id
     Event.connection.add_index :events, :id, name: 'index_on_id'
     stream = StringIO.new


### PR DESCRIPTION
#### Schema dumping
- This pr enables the dumping of partitioned tables in the `db/schema.rb` file.
- When the Postgres version enables it and if the Rails version doesn't already do it, it also dumps indexes and foreign keys of the partitioned table.
- This does not dump partitions of those partitioned tables.

TODO:
- [ ] Handle the `id` column.
- [ ] More tests
- [x] Add back options from the `create_table` method.
- [x] Move "dumping translation" (`create_table` -> `create_xxxx_partition`) to a `Tablature::PartitionedTable#to_schema` method.

Closes #3.